### PR TITLE
Fix API connection

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         build: .
         environment:
             - ROCKET_SECRET_KEY=${ROCKET_SECRET_KEY}
-            - ROCKET_DATABASES='{postgres={url="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}"}}'
+            - ROCKET_DATABASES={postgres={url=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db/${POSTGRES_DB}}}
         depends_on:
             - db
         ports:
@@ -19,7 +19,7 @@ services:
         environment:
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-            - POSTGRES_DB=${POSTGRES_DB}db
+            - POSTGRES_DB=${POSTGRES_DB}
         volumes:
             - postgres_data:/var/lib/postgresql/data
         ports:


### PR DESCRIPTION
🤦🏻 Had a typo in the database name.

Also ditches the quotation marks because the encoding is screwing it up when passed to `docker`, even though it works just fine with the quotes locally.