### PR TITLE
chore: Bump edition to 2021

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dicebag-server"
 version = "0.1.0"
 authors = ["Lane Sawyer <github@lanesaywer.dev>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 diesel = { version = "1.4.8", features = ["postgres", "64-column-tables"] }

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dicebag"
 version = "0.1.0"
 authors = ["Lane Sawyer <github@lanesawyer.dev>"]
-edition = "2018"
+edition = "2021"
 
 [profile.release]
 # Increases execution speed at the cost of compile time


### PR DESCRIPTION
# chore: Bump edition to 2021

Bumps the edition to 2021 to get rid of some console warning logs and be on the latest version