### PR TITLE
chore: Fix up Dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
 - package-ecosystem: cargo
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
+    interval: 'monthly'
+  commit-message:
+    prefix: 'chore(deps):'


### PR DESCRIPTION
# chore: Fix up Dependabot settings

Fixes Dependabot settings to start using Conventional Commit prefixes and not run every single day